### PR TITLE
ensure AB::MB in configure_requires

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -16,6 +16,7 @@ copyright_year   = 2014
 [AutoPrereqs]
 
 [Alien]
+:version = 0.023
 repo = file:inc
 name = gcrypt
 pattern_prefix = libgcrypt-


### PR DESCRIPTION
This will force a version of the [Alien] plugin that will ensure that `Alien::Base::ModuleBuild` is specified in configure_requires instead of `Alien::Base`.  For the rationale for this please see https://github.com/Perl5-Alien/Alien-Base/issues/157
